### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Then `dd` it to the sd card (or usb or eMMC)
 DEV=/dev/mmcblkX
 UBOOT=result/u-boot.bin.sd.bin
 dd if=$UBOOT of=$DEV conv=fsync,notrunc bs=512 skip=1 seek=1
-dd if=$UBOOT of=$DEV conv=fsync,notrunc bs=1 count=444
 sync
 ```
 


### PR DESCRIPTION
You don't need this
```
dd if=$UBOOT of=$DEV conv=fsync,notrunc bs=1 count=444
```
The `aml_encrypt_g12b` will fill the first 512b of the `.sd.bin` image with random data.

440 is the offset for the disk signature. 444 will thus overwrite even the disk signature with random data.
The `aml_encrypt_g12b` tool also produces a `u-boot.bin` without the `.sd.bin` suffix. That one can be
used with just `seek=1` (e.g. write from 512 onwards).