### PR TITLE
Simplify the boot loader

### DIFF
--- a/packages/uboot_odroid_n2/default.nix
+++ b/packages/uboot_odroid_n2/default.nix
@@ -15,7 +15,7 @@ buildUBoot {
   };
   defconfig = "odroid-n2_defconfig";
   extraMeta.platforms = [ "aarch64-linux" ];
-  filesToInstall = [ "u-boot.bin.sd.bin" ];
+  filesToInstall = [ "u-boot.bin" ];
   # TODO workout what the /tmp error is
   preBuild = ''
   cp -Rf ${extra} extra
@@ -40,6 +40,6 @@ buildUBoot {
   '';
   installPhase = ''
     mkdir -p $out
-    cp extra/fip/u-boot.bin.sd.bin $out
+    cp extra/fip/u-boot.bin $out
   '';
 }

--- a/packages/uboot_odroid_n2/extra/pack.sh
+++ b/packages/uboot_odroid_n2/extra/pack.sh
@@ -62,20 +62,15 @@ sh fip/blx_fix.sh \
 	fip/bl2_new.bin \
 	bl2
 
-fip/aml_encrypt_g12b --bl30sig --input fip/bl30_new.bin \
-					--output fip/bl30_new.bin.g12a.enc \
-					--level v3
-fip/aml_encrypt_g12b --bl3sig --input fip/bl30_new.bin.g12a.enc \
-					--output fip/bl30_new.bin.enc \
-					--level v3 --type bl30
-fip/aml_encrypt_g12b --bl3sig --input fip/bl31.img \
-					--output fip/bl31.img.enc \
-					--level v3 --type bl31
-fip/aml_encrypt_g12b --bl3sig --input fip/bl33.bin --compress lz4 \
-					--output fip/bl33.bin.enc \
-					--level v3 --type bl33 --compress lz4
-fip/aml_encrypt_g12b --bl2sig --input fip/bl2_new.bin \
-					--output fip/bl2.n.bin.sig
+# --level and the --type have no effect without encryption keys.
+# --compress lz4 is not necessary if we don't want to try to fit
+# the whole boot loader into 1mb. Compressed will give us ~980k,
+# whereas uncompressed will yield ~1.3M.
+fip/aml_encrypt_g12b --bl30sig --input fip/bl30_new.bin --output fip/bl30_new.tmp
+fip/aml_encrypt_g12b --bl3sig  --input fip/bl30_new.tmp --output fip/bl30_new.bin.enc
+fip/aml_encrypt_g12b --bl3sig  --input fip/bl31.img     --output fip/bl31.img.enc
+fip/aml_encrypt_g12b --bl3sig  --input fip/bl33.bin     --output fip/bl33.bin.enc
+fip/aml_encrypt_g12b --bl2sig  --input fip/bl2_new.bin  --output fip/bl2.n.bin.sig
 fip/aml_encrypt_g12b --bootmk \
 		--output fip/u-boot.bin \
 		--bl2 fip/bl2.n.bin.sig \
@@ -94,5 +89,4 @@ fip/aml_encrypt_g12b --bootmk \
 
 echo "# Write the image to SD with"
 echo DEV=/dev/mmcblkX
-echo dd if=fip/u-boot.bin.sd.bin of=\$DEV conv=fsync,notrunc bs=512 skip=1 seek=1
-echo dd if=fip/u-boot.bin.sd.bin of=\$DEV conv=fsync,notrunc bs=1 count=444
+echo dd if=fip/u-boot.bin of=\$DEV conv=fsync,notrunc bs=512 skip=1 seek=1


### PR DESCRIPTION
This drops quite a bit of superfluous commands.

Also the first 512byte of the `.sd.bin` file are just
random noise, so we can just use the `u-boot.bin`
and write from 512 onwards.